### PR TITLE
Fix ServerInfo build error in src/server.rs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,4 +29,3 @@ rstest = "0.26.1"
 [lib]
 name = "mq_mcp"
 path = "src/lib.rs"
-

--- a/src/server.rs
+++ b/src/server.rs
@@ -219,18 +219,15 @@ impl Server {
 #[tool_handler]
 impl ServerHandler for Server {
     fn get_info(&self) -> ServerInfo {
-        ServerInfo {
-            protocol_version: ProtocolVersion::V_2025_06_18,
-            instructions: Some(
-                "mq is a tool for processing markdown content with a jq-like syntax.".into(),
-            ),
-            capabilities: ServerCapabilities::builder()
+        ServerInfo::new(
+            ServerCapabilities::builder()
                 .enable_logging()
                 .enable_tools()
                 .enable_tool_list_changed()
                 .build(),
-            ..Default::default()
-        }
+        )
+        .with_protocol_version(ProtocolVersion::V_2025_06_18)
+        .with_instructions("mq is a tool for processing markdown content with a jq-like syntax.")
     }
 }
 


### PR DESCRIPTION
Modified `src/server.rs` to use `ServerInfo::new(...)` and fluent builder methods instead of a struct literal, fixing the `E0639` non-exhaustive struct error. All project tests passed.

---
*PR created automatically by Jules for task [2737655037743106844](https://jules.google.com/task/2737655037743106844) started by @harehare*