### PR TITLE
feat: add markdown extraction tools and section module support

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,32 +36,72 @@ source ~/.zshrc  # or ~/.bashrc for bash users
 
 ## Implementation
 
-The server implements four MCP tools:
+The server implements the following MCP tools:
 
-- `html_to_markdown`: Converts HTML to Markdown and executes mq queries
-- `extract_markdown`: Executes mq queries on Markdown content
-- `available_functions`: Returns available functions for mq queries
-- `available_selectors`: Returns available selectors for mq queries
+### Query Tools
+
+- `html_to_markdown`: Converts HTML to Markdown and executes an mq query
+- `extract_markdown`: Executes a custom mq query on Markdown content
+
+### Selector Tools
+
+These tools apply a fixed mq selector to Markdown content:
+
+| Tool | mq selector | Description |
+|------|-------------|-------------|
+| `extract_headings` | `.h` | All headings (h1–h6) |
+| `extract_code_blocks` | `.code` | All fenced code blocks |
+| `extract_todos` | `.todo` | Unchecked task list items |
+| `extract_done_tasks` | `.done` | Checked task list items |
+| `extract_links` | `.link` | All links |
+| `extract_images` | `.image` | All images |
+| `extract_tables` | `.table` | All table cells |
+| `extract_text` | `.text` | Paragraph text nodes |
+| `extract_blockquotes` | `.blockquote` | All blockquotes |
+
+### Section Tools
+
+These tools use the mq [section module](https://mqlang.org/book/start/example.html) to operate on document sections (heading + body):
+
+| Tool | Description |
+|------|-------------|
+| `extract_sections` | Split document into all sections and return as Markdown |
+| `extract_section` | Extract a single section by title (partial, case-sensitive match) |
+| `extract_toc` | Generate an indented table of contents from headings |
+
+### Discovery Tools
+
+- `available_functions`: Returns available mq functions with descriptions and parameters
+- `available_selectors`: Returns available mq selectors with descriptions
 
 ### Tool Parameters
 
 #### html_to_markdown
 
 - `html` (string): HTML content to process
-- `query` (optional string): mq query to execute
+- `query` (optional string): mq query to execute (default: `identity()`)
 
 #### extract_markdown
 
 - `markdown` (string): Markdown content to process
 - `query` (string): mq query to execute
 
-#### available_functions
+#### extract_headings / extract_code_blocks / extract_todos / extract_done_tasks / extract_links / extract_images / extract_tables / extract_text / extract_blockquotes
 
-No parameters. Returns JSON with function names, descriptions, parameters, and example queries.
+- `markdown` (string): Markdown content to process
 
-#### available_selectors
+#### extract_sections / extract_toc
 
-No parameters. Returns JSON with selector names, descriptions, and parameters.
+- `markdown` (string): Markdown content to process
+
+#### extract_section
+
+- `markdown` (string): Markdown content to process
+- `title` (string): Section heading text to match (partial, case-sensitive)
+
+#### available_functions / available_selectors
+
+No parameters.
 
 ## Configuration
 

--- a/src/server.rs
+++ b/src/server.rs
@@ -33,6 +33,102 @@ struct QueryForMarkdown {
     query: String,
 }
 
+#[derive(Debug, rmcp::serde::Deserialize, schemars::JsonSchema)]
+struct MarkdownInput {
+    #[schemars(description = "The markdown content to process")]
+    markdown: String,
+}
+
+#[derive(Debug, rmcp::serde::Deserialize, schemars::JsonSchema)]
+struct ExtractSectionInput {
+    #[schemars(description = "The markdown content to process")]
+    markdown: String,
+    #[schemars(description = "The section title to extract (partial match)")]
+    title: String,
+}
+
+impl Server {
+    fn eval_query(&self, markdown: &str, query: &str) -> McpResult {
+        let mut engine = mq_lang::DefaultEngine::default();
+        engine.load_builtin_module();
+
+        let parsed = mq_markdown::Markdown::from_html_str(markdown).map_err(|e| {
+            ErrorData::parse_error(
+                "Failed to parse markdown",
+                Some(serde_json::Value::String(e.to_string())),
+            )
+        })?;
+
+        let values = engine
+            .eval(
+                query,
+                parsed.nodes.into_iter().map(mq_lang::RuntimeValue::from),
+            )
+            .map_err(|e| {
+                ErrorData::invalid_request(
+                    "Failed to query",
+                    Some(serde_json::Value::String(e.to_string())),
+                )
+            })?;
+
+        Ok(CallToolResult::success(
+            values
+                .into_iter()
+                .filter_map(|value| {
+                    if value.is_none() || value.is_empty() {
+                        None
+                    } else {
+                        Some(Content::text(value.to_string()))
+                    }
+                })
+                .collect(),
+        ))
+    }
+
+    fn eval_aggregate(&self, markdown: &str, query: &str) -> McpResult {
+        let mut engine = mq_lang::DefaultEngine::default();
+        engine.load_builtin_module();
+
+        let parsed = mq_markdown::Markdown::from_html_str(markdown).map_err(|e| {
+            ErrorData::parse_error(
+                "Failed to parse markdown",
+                Some(serde_json::Value::String(e.to_string())),
+            )
+        })?;
+
+        let all_nodes: Vec<mq_lang::RuntimeValue> = parsed
+            .nodes
+            .into_iter()
+            .map(mq_lang::RuntimeValue::from)
+            .collect();
+        let input = mq_lang::RuntimeValue::Array(all_nodes);
+
+        let values = engine
+            .eval(query, std::iter::once(input))
+            .map_err(|e| {
+                ErrorData::invalid_request(
+                    "Failed to query",
+                    Some(serde_json::Value::String(e.to_string())),
+                )
+            })?;
+
+        Ok(CallToolResult::success(
+            values
+                .into_iter()
+                .flat_map(|value| match value {
+                    mq_lang::RuntimeValue::Array(arr) => arr
+                        .into_iter()
+                        .filter(|v| !v.is_none() && !v.is_empty())
+                        .map(|v| Content::text(v.to_string()))
+                        .collect::<Vec<_>>(),
+                    v if v.is_none() || v.is_empty() => vec![],
+                    v => vec![Content::text(v.to_string())],
+                })
+                .collect(),
+        ))
+    }
+}
+
 #[derive(Debug, rmcp::serde::Serialize, rmcp::serde::Deserialize, schemars::JsonSchema)]
 struct FunctionInfo {
     #[schemars(description = "The function name")]
@@ -82,11 +178,7 @@ impl Server {
         let values = engine
             .eval(
                 &query.unwrap_or("identity()".to_string()),
-                markdown
-                    .nodes
-                    .clone()
-                    .into_iter()
-                    .map(mq_lang::RuntimeValue::from),
+                markdown.nodes.into_iter().map(mq_lang::RuntimeValue::from),
             )
             .map_err(|e| {
                 ErrorData::invalid_request(
@@ -110,49 +202,125 @@ impl Server {
     }
 
     #[tool(
-        description = "Extract from markdown content. Selectors and functions listed in the available_selectors and available_functions tools can be used."
+        description = "Extract from markdown content using a custom mq query. Selectors and functions listed in the available_selectors and available_functions tools can be used."
     )]
     fn extract_markdown(
         &self,
         Parameters(QueryForMarkdown { markdown, query }): Parameters<QueryForMarkdown>,
-    ) -> Result<CallToolResult, ErrorData> {
-        let mut engine = mq_lang::DefaultEngine::default();
-        engine.load_builtin_module();
+    ) -> McpResult {
+        self.eval_query(&markdown, &query)
+    }
 
-        let markdown = mq_markdown::Markdown::from_html_str(&markdown).map_err(|e| {
-            ErrorData::parse_error(
-                "Failed to parse markdown",
-                Some(serde_json::Value::String(e.to_string())),
-            )
-        })?;
-        let values = engine
-            .eval(
-                &query,
-                markdown
-                    .nodes
-                    .clone()
-                    .into_iter()
-                    .map(mq_lang::RuntimeValue::from),
-            )
-            .map_err(|e| {
-                ErrorData::invalid_request(
-                    "Failed to query",
-                    Some(serde_json::Value::String(e.to_string())),
-                )
-            })?;
+    #[tool(description = "Extract all headings (h1–h6) from markdown content.")]
+    fn extract_headings(
+        &self,
+        Parameters(MarkdownInput { markdown }): Parameters<MarkdownInput>,
+    ) -> McpResult {
+        self.eval_query(&markdown, ".h")
+    }
 
-        Ok(CallToolResult::success(
-            values
-                .into_iter()
-                .filter_map(|value| {
-                    if value.is_none() || value.is_empty() {
-                        None
-                    } else {
-                        Some(Content::text(value.to_string()))
-                    }
-                })
-                .collect::<Vec<_>>(),
-        ))
+    #[tool(description = "Extract all fenced code blocks from markdown content.")]
+    fn extract_code_blocks(
+        &self,
+        Parameters(MarkdownInput { markdown }): Parameters<MarkdownInput>,
+    ) -> McpResult {
+        self.eval_query(&markdown, ".code")
+    }
+
+    #[tool(description = "Extract all unchecked task list items (todos) from markdown content.")]
+    fn extract_todos(
+        &self,
+        Parameters(MarkdownInput { markdown }): Parameters<MarkdownInput>,
+    ) -> McpResult {
+        self.eval_query(&markdown, ".todo")
+    }
+
+    #[tool(description = "Extract all checked task list items (done tasks) from markdown content.")]
+    fn extract_done_tasks(
+        &self,
+        Parameters(MarkdownInput { markdown }): Parameters<MarkdownInput>,
+    ) -> McpResult {
+        self.eval_query(&markdown, ".done")
+    }
+
+    #[tool(description = "Extract all links from markdown content.")]
+    fn extract_links(
+        &self,
+        Parameters(MarkdownInput { markdown }): Parameters<MarkdownInput>,
+    ) -> McpResult {
+        self.eval_query(&markdown, ".link")
+    }
+
+    #[tool(description = "Extract all images from markdown content.")]
+    fn extract_images(
+        &self,
+        Parameters(MarkdownInput { markdown }): Parameters<MarkdownInput>,
+    ) -> McpResult {
+        self.eval_query(&markdown, ".image")
+    }
+
+    #[tool(description = "Extract all tables from markdown content.")]
+    fn extract_tables(
+        &self,
+        Parameters(MarkdownInput { markdown }): Parameters<MarkdownInput>,
+    ) -> McpResult {
+        self.eval_query(&markdown, ".table")
+    }
+
+    #[tool(description = "Extract all paragraph text nodes from markdown content.")]
+    fn extract_text(
+        &self,
+        Parameters(MarkdownInput { markdown }): Parameters<MarkdownInput>,
+    ) -> McpResult {
+        self.eval_query(&markdown, ".text")
+    }
+
+    #[tool(description = "Extract all blockquotes from markdown content.")]
+    fn extract_blockquotes(
+        &self,
+        Parameters(MarkdownInput { markdown }): Parameters<MarkdownInput>,
+    ) -> McpResult {
+        self.eval_query(&markdown, ".blockquote")
+    }
+
+    #[tool(
+        description = "Split markdown content into sections (heading + body) and return all of them as markdown."
+    )]
+    fn extract_sections(
+        &self,
+        Parameters(MarkdownInput { markdown }): Parameters<MarkdownInput>,
+    ) -> McpResult {
+        self.eval_aggregate(
+            &markdown,
+            r#"import "section" | section::sections() | section::collect()"#,
+        )
+    }
+
+    #[tool(
+        description = "Extract a specific section (heading + body) from markdown content by title. Performs a partial, case-sensitive match on the heading text."
+    )]
+    fn extract_section(
+        &self,
+        Parameters(ExtractSectionInput { markdown, title }): Parameters<ExtractSectionInput>,
+    ) -> McpResult {
+        let escaped = title.replace('\\', r"\\").replace('"', r#"\""#);
+        let query = format!(
+            r#"import "section" | section::section("{escaped}") | section::collect()"#
+        );
+        self.eval_aggregate(&markdown, &query)
+    }
+
+    #[tool(
+        description = "Generate a table of contents from the headings in markdown content. Returns a list of indented entries."
+    )]
+    fn extract_toc(
+        &self,
+        Parameters(MarkdownInput { markdown }): Parameters<MarkdownInput>,
+    ) -> McpResult {
+        self.eval_aggregate(
+            &markdown,
+            r#"import "section" | section::sections() | section::toc()"#,
+        )
     }
 
     #[tool(description = "Get available selectors that can be used in mq query.")]
@@ -375,6 +543,212 @@ mod tests {
                 );
             }
         }
+    }
+
+    fn ok_texts(result: CallToolResult) -> Vec<String> {
+        assert!(!result.is_error.unwrap_or_default());
+        result
+            .content
+            .into_iter()
+            .map(|c| c.as_text().map(|t| t.text.clone()).unwrap_or_default())
+            .collect()
+    }
+
+    #[rstest]
+    #[case("# H1\n\n## H2\n\n### H3", vec!["# H1", "## H2", "### H3"])]
+    #[case("No headings here.", vec![])]
+    fn test_extract_headings(#[case] markdown: &str, #[case] expected: Vec<&str>) {
+        let server = Server::new().unwrap();
+        let result = server
+            .extract_headings(Parameters(MarkdownInput {
+                markdown: markdown.to_string(),
+            }))
+            .unwrap();
+        assert_eq!(ok_texts(result), expected);
+    }
+
+    #[rstest]
+    #[case("```rust\nfn main() {}\n```\n\n```python\nprint(\"hi\")\n```", 2)]
+    #[case("No code blocks.", 0)]
+    fn test_extract_code_blocks(#[case] markdown: &str, #[case] count: usize) {
+        let server = Server::new().unwrap();
+        let result = server
+            .extract_code_blocks(Parameters(MarkdownInput {
+                markdown: markdown.to_string(),
+            }))
+            .unwrap();
+        assert_eq!(ok_texts(result).len(), count);
+    }
+
+    #[rstest]
+    #[case("- [ ] Buy milk\n- [x] Buy eggs\n- [ ] Buy bread", vec!["- [ ] Buy milk", "- [ ] Buy bread"])]
+    #[case("- [x] Done task", vec![])]
+    #[case("No list.", vec![])]
+    fn test_extract_todos(#[case] markdown: &str, #[case] expected: Vec<&str>) {
+        let server = Server::new().unwrap();
+        let result = server
+            .extract_todos(Parameters(MarkdownInput {
+                markdown: markdown.to_string(),
+            }))
+            .unwrap();
+        assert_eq!(ok_texts(result), expected);
+    }
+
+    #[rstest]
+    #[case("- [ ] Todo\n- [x] Done", vec!["- [x] Done"])]
+    #[case("- [ ] Only todo", vec![])]
+    fn test_extract_done_tasks(#[case] markdown: &str, #[case] expected: Vec<&str>) {
+        let server = Server::new().unwrap();
+        let result = server
+            .extract_done_tasks(Parameters(MarkdownInput {
+                markdown: markdown.to_string(),
+            }))
+            .unwrap();
+        assert_eq!(ok_texts(result), expected);
+    }
+
+    #[rstest]
+    #[case("[Google](https://google.com) and [Rust](https://rust-lang.org)", 2)]
+    #[case("No links here.", 0)]
+    fn test_extract_links(#[case] markdown: &str, #[case] count: usize) {
+        let server = Server::new().unwrap();
+        let result = server
+            .extract_links(Parameters(MarkdownInput {
+                markdown: markdown.to_string(),
+            }))
+            .unwrap();
+        assert_eq!(ok_texts(result).len(), count);
+    }
+
+    #[rstest]
+    #[case("![Alt](img.png) and ![Logo](logo.svg)", 2)]
+    #[case("No images.", 0)]
+    fn test_extract_images(#[case] markdown: &str, #[case] count: usize) {
+        let server = Server::new().unwrap();
+        let result = server
+            .extract_images(Parameters(MarkdownInput {
+                markdown: markdown.to_string(),
+            }))
+            .unwrap();
+        assert_eq!(ok_texts(result).len(), count);
+    }
+
+    #[rstest]
+    // .table returns individual table cells; a 2-column × 2-row table (header + data) = 4 cells
+    #[case("| A | B |\n|---|---|\n| 1 | 2 |", 4)]
+    #[case("No tables.", 0)]
+    fn test_extract_tables(#[case] markdown: &str, #[case] count: usize) {
+        let server = Server::new().unwrap();
+        let result = server
+            .extract_tables(Parameters(MarkdownInput {
+                markdown: markdown.to_string(),
+            }))
+            .unwrap();
+        assert_eq!(ok_texts(result).len(), count);
+    }
+
+    #[rstest]
+    #[case("Hello world.\n\nSecond paragraph.", 2)]
+    // from_html_str treats bare "# Only heading" as a single text paragraph (not a heading)
+    #[case("# Only heading", 1)]
+    fn test_extract_text(#[case] markdown: &str, #[case] count: usize) {
+        let server = Server::new().unwrap();
+        let result = server
+            .extract_text(Parameters(MarkdownInput {
+                markdown: markdown.to_string(),
+            }))
+            .unwrap();
+        assert_eq!(ok_texts(result).len(), count);
+    }
+
+    #[rstest]
+    #[case("> A quote.\n\n> Another quote.", 2)]
+    #[case("No blockquotes.", 0)]
+    fn test_extract_blockquotes(#[case] markdown: &str, #[case] count: usize) {
+        let server = Server::new().unwrap();
+        let result = server
+            .extract_blockquotes(Parameters(MarkdownInput {
+                markdown: markdown.to_string(),
+            }))
+            .unwrap();
+        assert_eq!(ok_texts(result).len(), count);
+    }
+
+    const SECTION_MD: &str = "\
+# Introduction\n\
+\n\
+Welcome.\n\
+\n\
+## Installation\n\
+\n\
+Run the command.\n\
+\n\
+## Usage\n\
+\n\
+Use it like this.\n";
+
+    #[test]
+    fn test_extract_sections() {
+        let server = Server::new().unwrap();
+        let result = server
+            .extract_sections(Parameters(MarkdownInput {
+                markdown: SECTION_MD.to_string(),
+            }))
+            .unwrap();
+        let texts = ok_texts(result);
+        assert!(!texts.is_empty());
+        let joined = texts.join("\n");
+        assert!(joined.contains("Introduction"));
+        assert!(joined.contains("Installation"));
+        assert!(joined.contains("Usage"));
+    }
+
+    #[rstest]
+    #[case("Installation", true)]
+    #[case("Nonexistent", false)]
+    fn test_extract_section(#[case] title: &str, #[case] should_have_content: bool) {
+        let server = Server::new().unwrap();
+        let result = server
+            .extract_section(Parameters(ExtractSectionInput {
+                markdown: SECTION_MD.to_string(),
+                title: title.to_string(),
+            }))
+            .unwrap();
+        let texts = ok_texts(result);
+        assert_eq!(!texts.is_empty(), should_have_content);
+        if should_have_content {
+            assert!(texts.join("\n").contains(title));
+        }
+    }
+
+    #[test]
+    fn test_extract_section_title_with_special_chars() {
+        let md = "## Section \"quoted\"\n\nContent.";
+        let server = Server::new().unwrap();
+        let result = server
+            .extract_section(Parameters(ExtractSectionInput {
+                markdown: md.to_string(),
+                title: "Section \"quoted\"".to_string(),
+            }))
+            .unwrap();
+        let texts = ok_texts(result);
+        assert!(!texts.is_empty());
+    }
+
+    #[test]
+    fn test_extract_toc() {
+        let server = Server::new().unwrap();
+        let result = server
+            .extract_toc(Parameters(MarkdownInput {
+                markdown: SECTION_MD.to_string(),
+            }))
+            .unwrap();
+        let texts = ok_texts(result);
+        assert!(!texts.is_empty());
+        let joined = texts.join("\n");
+        assert!(joined.contains("Introduction"));
+        assert!(joined.contains("Installation"));
+        assert!(joined.contains("Usage"));
     }
 
     #[test]


### PR DESCRIPTION
Add 12 new MCP tools covering fixed-query selectors (.h, .code, .todo,
.done, .link, .image, .table, .text, .blockquote) and section module
operations (extract_sections, extract_section, extract_toc).